### PR TITLE
Fix ControlExplosion()

### DIFF
--- a/TOMB5/game/traps.cpp
+++ b/TOMB5/game/traps.cpp
@@ -87,7 +87,7 @@ void ControlExplosion(short item_number)
 			TriggerExplosionSparks(item->pos.x_pos, item->pos.y_pos, item->pos.z_pos, 3, -2, uw, item->room_number);
 
 			for (int i = 0; i < item->item_flags[2]; i++)
-				TriggerExplosionSparks(item->pos.x_pos + (GetRandomControl() % 128 - 64) * item->item_flags[2], item->pos.y_pos + (GetRandomControl() % 128 - 64) * item->item_flags[2], item->pos.z_pos + (GetRandomControl() % 128 - 64) * item->item_flags[2], 2, 0, i, item->room_number);
+				TriggerExplosionSparks(item->pos.x_pos + (GetRandomControl() % 128 - 64) * item->item_flags[2], item->pos.y_pos + (GetRandomControl() % 128 - 64) * item->item_flags[2], item->pos.z_pos + (GetRandomControl() % 128 - 64) * item->item_flags[2], 2, 0, uw, item->room_number);
 
 			pos.x = item->pos.x_pos;
 			pos.y = item->pos.y_pos - 128;


### PR DESCRIPTION
Caused wrong rendering (blue/green) colours in software mode, and I think some bad rendering too in HW mode, but nearly invisible due to too much light.