### PR TITLE
Fix bink Video playback

### DIFF
--- a/TOMB5/game/savegame.cpp
+++ b/TOMB5/game/savegame.cpp
@@ -852,9 +852,6 @@ void RestoreLevelData(long FullSave)
 						ReadSG(creature, 22);
 						creature->enemy = (ITEM_INFO*)((long)creature->enemy + (long)malloc_buffer);
 
-						if (creature->enemy < 0)
-							creature->enemy = 0;
-
 						ReadSG(&creature->ai_target.object_number, sizeof(short));
 						ReadSG(&creature->ai_target.room_number, sizeof(short));
 						ReadSG(&creature->ai_target.box_number, sizeof(ushort));

--- a/TOMB5/specific/fmv.cpp
+++ b/TOMB5/specific/fmv.cpp
@@ -122,13 +122,13 @@ long PlayFmv(long num)
 	dm = App.DXInfo.nDisplayMode;
 	current = &modes[dm];
 
-	if (current->bpp != 16 || current->w != 640 || current->h != 480)
+	if (current->bpp != 32 || current->w != 640 || current->h != 480)
 	{
 		ndms = G_dxinfo->DDInfo[G_dxinfo->nDD].D3DDevices[G_dxinfo->nD3D].nDisplayModes;
 
 		for (int i = 0; i < ndms; i++, modes++)
 		{
-			if (modes->bpp == 16 && modes->w == 640 && modes->h == 480)
+			if (modes->bpp == 32 && modes->w == 640 && modes->h == 480)
 			{
 				App.DXInfo.nDisplayMode = i;
 				break;


### PR DESCRIPTION
Hi. With builds compiled from commit https://github.com/Trxyebeep/TOMB5/commit/8f2192cd3241c5571382c795521466a2a350d20b onwards, Bink Video playback is buggy: the video is shown in a small window at the top left of the screen.
I looked at the Tomb4 code and noticed this little error. Videos now play normally in fullscreen.

Test: [tomb5.zip](https://github.com/Trxyebeep/TOMB5/files/15287953/tomb5.zip)
